### PR TITLE
Changed the Events and Contact just links to Meetup and Discord

### DIFF
--- a/app/components/header/navItems.ts
+++ b/app/components/header/navItems.ts
@@ -6,11 +6,17 @@ type NavItem = {
   faIcon?: FaBrand;
 };
 export default [
-  {text:"About", href: '/about'},
-  { text: "Events", href: "#event-showcase" },
+  { 
+    text:"About",
+    href: "/about"
+  },
+  { 
+    text: "Events", 
+    href: "/#event-showcase" 
+  },
   {
     text: "Contact",
-    href: "", //need information
+    href: "/#event-showcase", //need information Right now just links to Meetup and Discord
   },
   {
     text: "Instagram",


### PR DESCRIPTION
In the **directory** _/app/components/header/_ 
The file named "_navitems.ts_" contains all the navigations to the different pages on the front end.

In the option for "_Events_" tab was changed from "_#event-showcase_" hyperlink reference to "_/#event-showcase_".

In the option for "_Contact_" also links to the same reference of "_/#event-showcase_".

The hyperlink "_/#event-showcase_" links directly to the Connect with Us part of the page where the links to the meetups and discord pages are located. 


